### PR TITLE
記事カードにtranscateを追加

### DIFF
--- a/components/molecules/ArticleSummary.tsx
+++ b/components/molecules/ArticleSummary.tsx
@@ -28,10 +28,13 @@ export const ArticleSummary = ({ user }: ArticleSummaryProps) => (
         <h2 className="tracking-widest text-xs title-font font-medium text-gray-400 mb-1">
           TITLE
         </h2>
-        <h1 className="title-font text-lg font-medium text-gray-900 mb-3">
-          タイトルです
+        <h1 className="title-font text-lg font-medium text-gray-900 mb-3 truncate">
+          タイトルですタイトルですタイトルですタイトルです
         </h1>
-        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        <div className="text-gray-500 line-clamp-2">
+        ありがとうございます。ありがとうございます。ありがとうございます。ありがとうございます。ありがとうございます。
+        </div>
+        
         <div className="flex items-center flex-wrap">
           <p className="text-sm md:text-base font-normal text-gray-400">
             日本 愛知

--- a/components/organisms/Articles.tsx
+++ b/components/organisms/Articles.tsx
@@ -15,7 +15,7 @@ interface ArticlesProps {
 
 export const Articles: React.VFC<ArticlesProps> = (props) => {
   return (
-    <article>
+    <>
       <Header user={props.user} />
       <div className="flex flex-wrap m-2">
         <ArticleSummary
@@ -48,6 +48,6 @@ export const Articles: React.VFC<ArticlesProps> = (props) => {
         />
       </div>
       <Footer />
-    </article>
+    </>
   );
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "@tailwindcss/line-clamp": "^0.3.1",
     "autoprefixer": "^10.4.2",
     "next": "12.0.10",
     "postcss": "^8",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,5 +16,7 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('@tailwindcss/line-clamp'),
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2419,6 +2419,11 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
+"@tailwindcss/line-clamp@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz#4d8441b509b87ece84e94f28a4aa9998413ab849"
+  integrity sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg==
+
 "@testing-library/dom@^8.3.0":
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.3.tgz#38fd63cbfe14557021e88982d931e33fb7c1a808"


### PR DESCRIPTION
## 背景
記事一覧のカードのタイトルや記事の中身が長かった場合、それらが改行されて見た目が悪くなることがあった。

## やったこと
transcateを追加

## やらなかったこと

## UIの変更箇所
<img width="376" alt="日台one_" src="https://user-images.githubusercontent.com/71773200/154824607-a162a9df-fd2b-4b1c-8f30-2d9a383190ce.png">

